### PR TITLE
Update to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_toon_shader"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 categories = ["game-engines", "graphics", "rendering", "game-development"]
 keywords = ["gamedev", "graphics", "bevy", "shader", "toon"]
@@ -11,12 +11,12 @@ repository = "https://github.com/tbillington/bevy_toon_shader"
 homepage = "https://github.com/tbillington/bevy_toon_shader"
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
   "bevy_pbr",
   "bevy_render",
   "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.11" }
-bevy_egui = "0.21.0"
+bevy = "0.12"
+bevy_egui = "0.23.0"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cargo run --example scene
 
 | bevy | bevy_toon_shader |
 | -- | -- |
+| 0.12 | 0.3 |
 | 0.11 | 0.2 |
 | 0.10 | 0.1 |
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,7 @@ use bevy::{
         },
     },
 };
-
-pub const TOON_SHADER_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 11079857277321826659);
+pub const TOON_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(11079857277321826659);
 
 #[derive(Default)]
 pub struct ToonShaderPlugin;
@@ -32,7 +30,7 @@ impl Plugin for ToonShaderPlugin {
     }
 }
 
-#[derive(AsBindGroup, TypeUuid, TypePath, Debug, Clone, Default)]
+#[derive(Asset, AsBindGroup, TypeUuid, TypePath, Debug, Clone, Default)]
 #[uuid = "7b033895-875f-4cb5-97ae-8601fcc37053"]
 #[uniform(0, ToonShaderMaterialUniform)]
 pub struct ToonShaderMaterial {
@@ -48,7 +46,7 @@ pub struct ToonShaderMaterial {
 
 impl Material for ToonShaderMaterial {
     fn fragment_shader() -> ShaderRef {
-        TOON_SHADER_HANDLE.typed().into()
+        TOON_SHADER_HANDLE.into()
     }
 
     fn specialize(

--- a/src/toon_shader.wgsl
+++ b/src/toon_shader.wgsl
@@ -13,10 +13,10 @@ var base_color_texture: texture_2d<f32>;
 @group(1) @binding(2)
 var base_color_sampler: sampler;
 
-#import bevy_pbr::mesh_vertex_output MeshVertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 @fragment
-fn fragment (in: MeshVertexOutput) -> @location(0) vec4<f32> {
+fn fragment (in: VertexOutput) -> @location(0) vec4<f32> {
     let base_color = material.color * textureSample(base_color_texture, base_color_sampler, in.uv);
     let normal = normalize(in.world_normal);
     let n_dot_l = dot(material.sun_dir, normal);


### PR DESCRIPTION
This PR updates `bevy_toon_shader` to version `0.3` which updates the version of bevy used to `0.12`.

There are no other changes.