### PR TITLE
Add fix to allow models without uvs to render

### DIFF
--- a/src/toon_shader.wgsl
+++ b/src/toon_shader.wgsl
@@ -17,14 +17,7 @@ var base_color_sampler: sampler;
 
 @fragment
 fn fragment (in: VertexOutput) -> @location(0) vec4<f32> {
-    // model may not have uvs for whatever reason. This is to allow it to still render.
-    #ifdef VERTEX_UVS_A
-        let uv = in.uv;
-    #else
-        let uv = 0.0;
-    #endif
-
-    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, uv);    
+    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, in.uv);
     let normal = normalize(in.world_normal);
     let n_dot_l = dot(material.sun_dir, normal);
     var light_intensity = 0.0;

--- a/src/toon_shader.wgsl
+++ b/src/toon_shader.wgsl
@@ -17,7 +17,14 @@ var base_color_sampler: sampler;
 
 @fragment
 fn fragment (in: VertexOutput) -> @location(0) vec4<f32> {
-    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, in.uv);
+    // if model doesn't have uvs, this lets it still render.
+    #ifdef VERTEX_UVS_A
+        let uv = in.uv;
+    #else
+        let uv = vec2(1.0, 1.0);
+    #endif
+
+    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, uv);
     let normal = normalize(in.world_normal);
     let n_dot_l = dot(material.sun_dir, normal);
     var light_intensity = 0.0;

--- a/src/toon_shader.wgsl
+++ b/src/toon_shader.wgsl
@@ -17,7 +17,14 @@ var base_color_sampler: sampler;
 
 @fragment
 fn fragment (in: VertexOutput) -> @location(0) vec4<f32> {
-    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, in.uv);
+    // model may not have uvs for whatever reason. This is to allow it to still render.
+    #ifdef VERTEX_UVS_A
+        let uv = in.uv;
+    #else
+        let uv = 0.0;
+    #endif
+
+    let base_color = material.color * textureSample(base_color_texture, base_color_sampler, uv);    
     let normal = normalize(in.world_normal);
     let n_dot_l = dot(material.sun_dir, normal);
     var light_intensity = 0.0;


### PR DESCRIPTION
I have some models which do not have uvs, and they don't render due to .uv being undefined. I added a conditional statement to the shader so that the shader results to vec(1.0, 1.0) if there are no given uvs for them